### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,6 @@ Moreover, in the event of a dispute, BitVM’s use of fraud proofs dovetails wel
 - [ASM to Bin](https://magical-frangipane-149aba.netlify.app/compiler)
 - [Citrea](https://www.blog.citrea.xyz/)
 - [Bitstake: A proof of stake bridge based on BitVM](https://lightco.in/2024/02/13/bitstake/)
-- [BitVM Research](https://github.com/bitlayer-org/BitVM-Research)
 
 ## Extra lists
 


### PR DESCRIPTION
remove bitvm research in [apps section](https://github.com/Rsync25/awesome-bitvm?tab=readme-ov-file#apps) because it shows in [resource section](https://github.com/Rsync25/awesome-bitvm?tab=readme-ov-file#resources)

(or keep it in the app section and remove the resource one if one wants a link to [bitlayer](https://www.bitlayer.org/) in the app section